### PR TITLE
feat: export white-listed annotations

### DIFF
--- a/test/super.span.test.ts
+++ b/test/super.span.test.ts
@@ -1,4 +1,5 @@
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { SEMATTRS_ENDUSER_ID } from '@opentelemetry/semantic-conventions';
 import { EnhancedReadableSpan } from '../src';
 
 describe('super.span test', () => {
@@ -86,6 +87,26 @@ describe('super.span test', () => {
       const enhancedSpan = new EnhancedReadableSpan(span);
 
       expect(enhancedSpan.isError()).toBeUndefined();
+    });
+
+    it('should return user if enduser.id is set', () => {
+      const span: ReadableSpan = {
+        attributes: { [SEMATTRS_ENDUSER_ID]: 'test' },
+      } as unknown as ReadableSpan;
+      const enhancedSpan = new EnhancedReadableSpan(span);
+
+      expect(enhancedSpan.getUser()).toEqual('test');
+    });
+
+    it('should return indexed attributes as annotations', () => {
+      const span: ReadableSpan = {
+        attributes: { [SEMATTRS_ENDUSER_ID]: 'test' },
+      } as unknown as ReadableSpan;
+      const enhancedSpan = new EnhancedReadableSpan(span);
+
+      expect(enhancedSpan.getAnnotations([SEMATTRS_ENDUSER_ID])).toEqual({
+        [SEMATTRS_ENDUSER_ID]: 'test',
+      });
     });
   });
 });


### PR DESCRIPTION
This merge request adds support for exporting arbitrary OpenTelemetry span attributes as xray annotations. 

## Description

I added a simple implementation for the existing `TODO` in `EnhancedReadableSpan.getAnnotations(...)`.

The exporter now has an additional constructor parameter called `indexedAttributes` which allows setting a list of attributes which should be indexed in xray as annotations.

The configuration is loosely based on the opentelemetry awsxray exporter [config](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/awsxrayexporter/config.go#L16-L19).

## Related Issue

This is related to #9 .

## Motivation and Context

Exporting OTEL span attributes to xray is a useful feature.

## How Has This Been Tested?

- Simple unit test
- Deployed to AWS and tested that span annotations are available in xray

## Documentation:

<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
