### PR TITLE
chore: update OpenTelemetry dependencies to version 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"license": "ISC",
 			"dependencies": {
 				"@aws-sdk/client-xray": "^3.0.0",
-				"@opentelemetry/core": "^1.25.1",
-				"@opentelemetry/sdk-trace-base": "^1.25.1",
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/sdk-trace-base": "^2.0.0",
 				"@opentelemetry/semantic-conventions": "^1.25.1",
 				"empty-deep": "^1.0.0",
 				"error-stack-parser": "^2.1.4"
@@ -19,8 +19,8 @@
 			"devDependencies": {
 				"@mridang/eslint-defaults": "^1.0.0",
 				"@opentelemetry/api": "^1.0.0",
-				"@opentelemetry/id-generator-aws-xray": "^1.2.2",
-				"@opentelemetry/resources": "1.25.1",
+				"@opentelemetry/id-generator-aws-xray": "^2.0.0",
+				"@opentelemetry/resources": "2.0.0",
 				"@semantic-release/commit-analyzer": "^13.0.0",
 				"@semantic-release/git": "^10.0.1",
 				"@semantic-release/github": "^10.0.5",
@@ -2159,29 +2159,31 @@
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
-			"integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+			"integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.25.1"
+				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/id-generator-aws-xray": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/id-generator-aws-xray/-/id-generator-aws-xray-1.2.2.tgz",
-			"integrity": "sha512-IKTqub5m/yI9+Cn4LJS+GbQrG7Ode9OWAmfJENmCMFTR5J2qGM7VOFaNpQFMICr7Wo8SUtgoJNbTxaQZ9AdMMA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/id-generator-aws-xray/-/id-generator-aws-xray-2.0.0.tgz",
+			"integrity": "sha512-o3/kw+HRd1uIe74F50EqFsStsAvTa/Xxv798j7xWFNfaDrSZmbFS8+L0CLJVTEtslSG5iVBhCKPbEtSn1ReKLA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "^1.0.0"
+				"@opentelemetry/sdk-trace-base": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0"
@@ -2202,12 +2204,13 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
-		"node_modules/@opentelemetry/resources": {
+		"node_modules/@opentelemetry/propagator-aws-xray/node_modules/@opentelemetry/core": {
 			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
-			"integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+			"integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
-				"@opentelemetry/core": "1.25.1",
 				"@opentelemetry/semantic-conventions": "1.25.1"
 			},
 			"engines": {
@@ -2217,26 +2220,54 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "1.25.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
-			"integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
-			"dependencies": {
-				"@opentelemetry/core": "1.25.1",
-				"@opentelemetry/resources": "1.25.1",
-				"@opentelemetry/semantic-conventions": "1.25.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/semantic-conventions": {
+		"node_modules/@opentelemetry/propagator-aws-xray/node_modules/@opentelemetry/semantic-conventions": {
 			"version": "1.25.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
 			"integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@opentelemetry/resources": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+			"integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+			"integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.0.0",
+				"@opentelemetry/resources": "2.0.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
+			"integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
 			}

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
 	"bugs": "https://github.com/mridang/exporter-xray/issues",
 	"dependencies": {
 		"@aws-sdk/client-xray": "^3.0.0",
-		"@opentelemetry/core": "^1.25.1",
-		"@opentelemetry/sdk-trace-base": "^1.25.1",
+		"@opentelemetry/core": "^2.0.0",
+		"@opentelemetry/sdk-trace-base": "^2.0.0",
 		"@opentelemetry/semantic-conventions": "^1.25.1",
 		"empty-deep": "^1.0.0",
 		"error-stack-parser": "^2.1.4"
@@ -58,8 +58,8 @@
 	"devDependencies": {
 		"@mridang/eslint-defaults": "^1.0.0",
 		"@opentelemetry/api": "^1.0.0",
-		"@opentelemetry/id-generator-aws-xray": "^1.2.2",
-		"@opentelemetry/resources": "1.25.1",
+		"@opentelemetry/id-generator-aws-xray": "^2.0.0",
+		"@opentelemetry/resources": "2.0.0",
 		"@semantic-release/commit-analyzer": "^13.0.0",
 		"@semantic-release/git": "^10.0.1",
 		"@semantic-release/github": "^10.0.5",

--- a/src/super.span.ts
+++ b/src/super.span.ts
@@ -238,7 +238,7 @@ export class EnhancedReadableSpan {
   }
 
   public getParentId() {
-    return this.span.parentSpanId;
+    return this.span.parentSpanContext?.spanId;
   }
 
   public getType() {


### PR DESCRIPTION
Hi, here are some version bumps and test adjustments. Let me know if you notice anything that needs to be changed still or feel free to adjust it.

PS: What do you think about moving the current `@aws-sdk/*` and `@opentelemetry/*` stuff from `dependencies` to `peerDependencies`?